### PR TITLE
Revert "minor cleanup"

### DIFF
--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -74,7 +74,6 @@ class TUFDownloader:
         function:
 
         {
-          "enable_logging": true,
           "repositories_dir": "repositories",
           "repository_dir": "repository-name",
           "target_path_patterns": ["^.*/(wheels/.*\\.whl)$"],
@@ -92,22 +91,27 @@ class TUFDownloader:
         with open(path_to_tuf_config_file) as tuf_config_file:
             tuf_config = json.load(tuf_config_file)
 
-        # NOTE: By default, we turn off TUF logging, and use the pip log
-        # instead.
-        tuf.settings.ENABLE_FILE_LOGGING = tuf_config.get('enable_logging',
-                                                          False)
+        # Reconfigure TUF logging, we can use the pip log output
+        tuf.settings.ENABLE_FILE_LOGGING = tuf_config.get('enable_logging', False)
 
         # NOTE: The directory where TUF metadata for *all* repositories are
         # kept.
-        tuf.settings.repositories_directory = tuf_config['repositories_dir']
+        if os.path.isabs(tuf_config['repositories_dir']):
+            tuf.settings.repositories_directory = tuf_config['repositories_dir']
+        else:
+            tuf.settings.repositories_directory = os.path.join(
+                os.path.dirname(path_to_tuf_config_file),
+                tuf_config['repositories_dir']
+            )
 
         # NOTE: Tell TUF where SSL certificates are kept.
         tuf.settings.ssl_certificates = certifi.where()
 
+
         # NOTE: The directory where the targets for *this* repository is
         # cached. We hard-code this keep this to a subdirectory dedicated to
         # this repository.
-        self.__targets_dir = os.path.join(tuf_config['repositories_dir'],
+        self.__targets_dir = os.path.join(tuf.settings.repositories_directory,
                                           tuf_config['repository_dir'],
                                           'targets')
 
@@ -170,6 +174,7 @@ class TUFDownloader:
 if 'TUF_CONFIG_FILE' in os.environ:
     import certifi
     import tuf.settings
+    tuf.settings.ENABLE_FILE_LOGGING = False
 
     from tuf.client.updater import Updater
 


### PR DESCRIPTION
This reverts commit b86ab178ebea540b395f8768147c85100a184668.

The changes made in PR #2 are necessary for the modified pip to play well with the tooling. None of those changes are significant, just disabling logging by default + more robust handling of the paths that may be set in the config json.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
