### PR TITLE
Update TUF to fix DoS attack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,8 +89,10 @@ setup(
         # NOTE: These are the optional requirements for enabling TUF.
         'tuf': [
             # At the time of writing (Jun 13 2018), this was the latest version
-            # of these libraries.
-            'tuf >= 0.12.dev1',
+            # of these libraries. We also constraint pip to install the stable,
+            # backwards-compatible release line of TUF (0.x.y), and never the
+            # experimental, backwards-incompatible release line (1.p.q).
+            'tuf >= 0.12.dev1, < 1.0.0',
             'securesystemslib [crypto] >= 0.11.2',
             # SSL certificates for TUF to talk to custom domains over TLS.
             'certifi >= 2018.4.16',

--- a/setup.py
+++ b/setup.py
@@ -88,9 +88,9 @@ setup(
         'testing': tests_require,
         # NOTE: These are the optional requirements for enabling TUF.
         'tuf': [
-            # At the time of writing (Jun 5 2018), this was the latest version
+            # At the time of writing (Jun 13 2018), this was the latest version
             # of these libraries.
-            'tuf >= 0.12.dev0',
+            'tuf >= 0.12.dev1',
             'securesystemslib [crypto] >= 0.11.2',
             # SSL certificates for TUF to talk to custom domains over TLS.
             'certifi >= 2018.4.16',

--- a/setup.py
+++ b/setup.py
@@ -88,12 +88,12 @@ setup(
         'testing': tests_require,
         # NOTE: These are the optional requirements for enabling TUF.
         'tuf': [
-            # At the time of writing (Jun 13 2018), this was the latest version
-            # of these libraries. We also constraint pip to install the stable,
-            # backwards-compatible release line of TUF (0.x.y), and never the
-            # experimental, backwards-incompatible release line (1.p.q).
-            'tuf >= 0.12.dev1, < 1.0.0',
-            'securesystemslib [crypto] >= 0.11.2',
+            # At the time of writing (Jun 19 2018), this was the latest version
+            # of these libraries. We also constraint pip to install only the
+            # latest, stable, backwards-compatible release line of TUF
+            # (0.11.x).
+            'tuf >= 0.11.1, < 0.12',
+            'securesystemslib [crypto, pynacl] >= 0.11.2',
             # SSL certificates for TUF to talk to custom domains over TLS.
             'certifi >= 2018.4.16',
         ]


### PR DESCRIPTION
This PR does do things:

1. Update TUF to fix [DoS attack](https://github.com/theupdateframework/tuf/issues/736)

2. Prevent `pip` from installing the experimental, backwards-incompatible release line of TUF (1.p.q), instead of the stable, backwards-compatible release line (0.x.y)