### PR TITLE
Leave temp dir before deleting it so it works on Windows

### DIFF
--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -296,6 +296,7 @@ class TUFDownloader:
                              .format(target_relpath))
             raise
         else:
+            os.chdir(prev_cwd)
             # Delete temp dir.
             shutil.rmtree(tempdir)
         finally:


### PR DESCRIPTION
```
WindowsError: [Error 32] The process cannot access the file because it is being used by another process: 'c:\\users\\ofek.lev\\appdata\\local\\temp\\tmpmvz3rw'
```