### PR TITLE
Turn off TUF + in-toto console logging by default

### DIFF
--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -389,7 +389,8 @@ if 'TUF_CONFIG_FILE' in os.environ:
     # You may turn toggle this behaviour using the "enable_logging" flag in the
     # TUF configuration file.
     tuf.settings.ENABLE_FILE_LOGGING = False
-    logging.getLogger("tuf").setLevel(logging.WARNING)
+    # NOTE: We set the TUF console logging level to CRITICAL and above.
+    logging.getLogger("tuf").setLevel(logging.CRITICAL)
     from tuf.client.updater import Updater
 
     from in_toto import verifylib

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -379,17 +379,22 @@ class TUFDownloader:
 if 'TUF_CONFIG_FILE' in os.environ:
     import glob
     import tempfile
-    import tuf.log
-    import tuf.settings
 
-    # We *always* turn off TUF logging.
+    # We always turn off TUF logging.
+    import tuf.settings
     tuf.settings.ENABLE_FILE_LOGGING = False
     # By default, set the TUF console logging level to >= CRITICAL.
+    import tuf.log
     logging.getLogger("tuf").setLevel(logging.CRITICAL)
-    # Also set non-verbose, quiet in-toto logging.
-    logging.getLogger("in_toto").setLevelVerboseOrQuiet(False, True)
+
+    # Import what we need from TUF.
     from tuf.client.updater import Updater
 
+    # Also set non-verbose, quiet in-toto logging.
+    import in_toto.log
+    logging.getLogger("in_toto").setLevelVerboseOrQuiet(False, True)
+
+    # Import what we need from in-toto.
     from in_toto import verifylib
     from in_toto.models.metadata import Metablock
     from in_toto.util import import_public_keys_from_files_as_dict

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -389,9 +389,7 @@ if 'TUF_CONFIG_FILE' in os.environ:
     # You may turn toggle this behaviour using the "enable_logging" flag in the
     # TUF configuration file.
     tuf.settings.ENABLE_FILE_LOGGING = False
-    tuf.log._DEFAULT_LOG_LEVEL = logging.WARNING
-    tuf.log._DEFAULT_CONSOLE_LOG_LEVEL = logging.WARNING
-    tuf.log.remove_console_handler()
+    logging.getLogger("tuf").setLevel(logging.WARNING)
     from tuf.client.updater import Updater
 
     from in_toto import verifylib

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -389,7 +389,7 @@ if 'TUF_CONFIG_FILE' in os.environ:
     # You may turn toggle this behaviour using the "enable_logging" flag in the
     # TUF configuration file.
     tuf.settings.ENABLE_FILE_LOGGING = False
-    tuf.log.remove_console_handler()
+    tuf.log._DEFAULT_LOG_LEVEL = logging.WARNING
     from tuf.client.updater import Updater
 
     from in_toto import verifylib

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -382,12 +382,14 @@ class TUFDownloader:
 if 'TUF_CONFIG_FILE' in os.environ:
     import glob
     import tempfile
+    import tuf.log
     import tuf.settings
 
     # NOTE: By default, we turn off TUF logging, and use the pip log instead.
     # You may turn toggle this behaviour using the "enable_logging" flag in the
     # TUF configuration file.
     tuf.settings.ENABLE_FILE_LOGGING = False
+    tuf.log.remove_console_handler()
     from tuf.client.updater import Updater
 
     from in_toto import verifylib

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -389,7 +389,7 @@ if 'TUF_CONFIG_FILE' in os.environ:
     # You may turn toggle this behaviour using the "enable_logging" flag in the
     # TUF configuration file.
     tuf.settings.ENABLE_FILE_LOGGING = False
-    tuf.log._DEFAULT_LOG_LEVEL = logging.WARNING
+    tuf.log.__DEFAULT_CONSOLE_LOG_LEVEL = logging.WARNING
     from tuf.client.updater import Updater
 
     from in_toto import verifylib

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -389,7 +389,9 @@ if 'TUF_CONFIG_FILE' in os.environ:
     # You may turn toggle this behaviour using the "enable_logging" flag in the
     # TUF configuration file.
     tuf.settings.ENABLE_FILE_LOGGING = False
-    tuf.log.__DEFAULT_CONSOLE_LOG_LEVEL = logging.WARNING
+    tuf.log._DEFAULT_LOG_LEVEL = logging.WARNING
+    tuf.log._DEFAULT_CONSOLE_LOG_LEVEL = logging.WARNING
+    tuf.log.remove_console_handler()
     from tuf.client.updater import Updater
 
     from in_toto import verifylib


### PR DESCRIPTION
* We can toggle them back on user configuration (setting `tuf_config.enable_logging` or the `TUF_ENABLE_LOGGING` env var).
* Use  `logger` instead of `logging` when we need to log.
* Change the level of logging for some statements.